### PR TITLE
feat: publish library to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           pip install build
       - name: Inject version into lib_version
         run: |
-          echo "__version__ = \"${{ steps.gitversion.outputs.majorMinorPatch }}\"" > lib_version/version.py
+          echo "__version__ = \"${{ steps.gitversion.outputs.semVer }}\"" > lib_version/version.py
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           pip install build
       - name: Inject version into lib_version
         run: |
-          echo "__version__ = \"${{ steps.gitversion.outputs.semVer }}\"" > lib_version/version.py
+          echo "__version__ = \"${{ steps.gitversion.outputs.majorMinorPatch }}\"" > lib_version/version.py
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,8 @@ jobs:
           pip install build
       - name: Inject version into lib_version
         run: |
-          echo "__version__ = \"${{ steps.gitversion.outputs.majorMinorPatch }}\"" > lib_version/version.py
+          VERSION="${{ steps.gitversion.outputs.majorMinorPatch }}.dev$(date +%Y%m%d%H%M)"
+          echo "__version__ = \"${VERSION}\"" > lib_version/version.py
       - name: Build package
         run: |
           python -m build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,11 @@ jobs:
           pip install build
       - name: Inject version into lib_version
         run: |
-          VERSION="${{ steps.gitversion.outputs.majorMinorPatch }}.dev$(date +%Y%m%d%H%M)"
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            VERSION="${{ steps.gitversion.outputs.majorMinorPatch }}"
+          else
+            VERSION="${{ steps.gitversion.outputs.majorMinorPatch }}.dev$(date +%Y%m%d%H%M)"
+          fi
           echo "__version__ = \"${VERSION}\"" > lib_version/version.py
       - name: Build package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           pip install build
       - name: Inject version into lib_version
         run: |
-          echo "__version__ = \"${sanitized_version}\"" > lib_version/version.py
+          echo "__version__ = \"${{ steps.gitversion.outputs.majorMinorPatch }}\"" > lib_version/version.py
       - name: Build package
         run: |
           python -m build
@@ -55,6 +55,10 @@ jobs:
         with:
           name: lib-version
           path: dist/*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The project uses GitHub Actions to automate the release process. When a new tag 
 1. Parse the version from the tag.
 2. Inject the version into `pyproject.toml`.
 3. Build the package.
+4. Publish the package to PyPI registry
 
 ## Contact
 

--- a/lib_version/version_util.py
+++ b/lib_version/version_util.py
@@ -2,8 +2,10 @@ import importlib.metadata
 
 class VersionUtil:
 
-    def get_version(package_name: str = "lib_version") -> str:
-        try:
-            return importlib.metadata.version(package_name)
-        except ImportError:
-            return "unknown"
+    def get_version():
+        for name in ["lib_version_team17", "lib_version"]:
+            try:
+                return importlib.metadata.version(name)
+            except importlib.metadata.PackageNotFoundError:
+                continue
+        return "unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "A version-aware library"
 requires-python = ">=3.10"
 
 [tool.setuptools]
-packages = ["lib_version_team17"]
+packages = ["lib_version"]
 
 [tool.setuptools_scm]
 version_scheme = "guess-next-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,13 @@ requires = ["setuptools>=68.0.0", "setuptools_scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "lib-version"
+name = "lib_version_team17"
 dynamic = ["version"]
 description = "A version-aware library"
 requires-python = ">=3.10"
 
 [tool.setuptools]
-packages = ["lib_version"]
+packages = ["lib_version_team17"]
 
 [tool.setuptools_scm]
 version_scheme = "guess-next-dev"


### PR DESCRIPTION
## Overview

Publishing this to PyPI to be used in local deployments.
The issue is that, during release action, the version is automatically generated in the `lib-version.version.py`, however, this is only visible within the release artifact. Now in app, where the lib-version is used, having this `lib_version @ git+https://github.com/remla25-team17/lib-version.git` will simply use the repository code, but not the updated code during the release. This causes error: `'lib_version.version' has no attribute '__version__'`.

## 📋 Pull Request Checklist

Please review and check all the following:

- [x] I have added an overview of the changes
- [x] I have tested my changes locally
- [x] I have updated documentation (if applicable)

---

## 🚀 Versioning (Required for GitVersion)

- [ ] The **PR includes a commit** with one of the following GitVersion tags in the **message**:
  - `#major` – breaking change
  - `#minor` – new feature
  - `#patch` – bug fix or minor update  
  - _If omitted, the version will default to_ `patch`
